### PR TITLE
feat: adding @commitlint/config-lerna-scopes to enforce scope as package

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,1 @@
-module.exports = {extends: ['@commitlint/config-conventional']};
+module.exports = { extends: ["@commitlint/config-conventional", "@commitlint/config-lerna-scopes"] };

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,17 @@
       "integrity": "sha512-DmA4ixkpv03qA1TVs1Bl25QsVym2bPL6pKapesALWIVggG3OpwqGZ55vN75Tx8xZoG7LFKrVyrt7kwhA7X8njQ==",
       "dev": true
     },
+    "@commitlint/config-lerna-scopes": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-lerna-scopes/-/config-lerna-scopes-7.2.1.tgz",
+      "integrity": "sha512-mwOchKzUKCINOUGlKPaavX9oF1vNT6kr6bZEshh6Hv1kfcNqBt9alLjbQq+4H/jHB7bvUER088pUaAjwHVP+7A==",
+      "dev": true,
+      "requires": {
+        "import-from": "2.1.0",
+        "resolve-pkg": "1.0.0",
+        "semver": "5.6.0"
+      }
+    },
     "@commitlint/ensure": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-7.2.0.tgz",
@@ -6265,6 +6276,23 @@
         }
       }
     },
+    "import-from": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/import-from/-/import-from-2.1.0.tgz",
+      "integrity": "sha1-M1238qev/VOqpHHUuAId7ja387E=",
+      "dev": true,
+      "requires": {
+        "resolve-from": "^3.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+          "dev": true
+        }
+      }
+    },
     "import-local": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
@@ -10015,6 +10043,23 @@
       "dev": true,
       "requires": {
         "global-dirs": "^0.1.0"
+      }
+    },
+    "resolve-pkg": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg/-/resolve-pkg-1.0.0.tgz",
+      "integrity": "sha1-4ZoV54rKLhJEYdySsuOUPvk0lNk=",
+      "dev": true,
+      "requires": {
+        "resolve-from": "^2.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+          "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
+          "dev": true
+        }
       }
     },
     "resolve-url": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "devDependencies": {
     "@commitlint/cli": "7.2.1",
     "@commitlint/config-conventional": "7.1.2",
+    "@commitlint/config-lerna-scopes": "7.2.1",
     "@commitlint/travis-cli": "7.2.1",
     "husky": "1.3.1",
     "jest": "23.6.0",


### PR DESCRIPTION
This is complementary to other rules, to enforce correct scope in commit messages.
For example, `chore(lol): something` won't be correct, but `chore(webpack-babel-optimize): something` will be