### PR TITLE
feat(webpack-quark-scss): add node sass as a dependency

### DIFF
--- a/packages/quarks/webpack-quark-scss/package.json
+++ b/packages/quarks/webpack-quark-scss/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@thc/webpack-chemistry": "1.0.0",
     "@thc/webpack-quark-css": "1.0.0",
+    "node-sass": "4.11.0",
     "sass-loader": "7.1.0"
   },
   "publishConfig": {


### PR DESCRIPTION
This PR is to fix #95

Node sass is indeed a peer dependency for this quark

